### PR TITLE
Return empty string instead of setting it to null

### DIFF
--- a/src/lib/core/streamer.php
+++ b/src/lib/core/streamer.php
@@ -458,7 +458,7 @@ class Streamer implements Serializable {
      */
     private function formatDate($ts, $type) {
         if ('' === $ts) {
-          $ts = null;
+            return $ts;
         }
       
         if($type == self::STREAMER_TYPE_DATE)


### PR DESCRIPTION
PHP 8.0 stopped allowing empty strings to be passed to gmstrftime. This led to the previously suggested change to replace the empty string with null. Unfortunately, that change collided with the gmstrftime also accepting null as a valid input where it would return the current time formatted as requested.

This led to contacts who had empty Anniversary and Birthday fields getting their empty strings replaced by nulls, and subsequently getting passed to gmstrftime which would assign them values of the current time.

The correct behaviour for the streamer in this instance is to just return the empty string

<!-- If you haven't released code to this project under github before please consider doing so now, the below is alternative wording that you can choose to use -->
<!-- Released under the GNU Affero General Public License (AGPL), version 3 and Trademark Additional Terms. -->

<!-- Thanks for sending a pull request! The below is all optional. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
...


Does this close any currently open issues?
------------------------------------------
...


Any relevant logs, error output, etc?
-------------------------------------
...


Where has this been tested?
---------------------------
**Server (please complete the following information):**
 - OS: [e.g. iOS]
 - PHP Version: [e.g. 8.2] 
 - Backend for: [e.g. Kopano, Zimbra, Mail-in-a-Box]
 - and Version: [e.g. git, 9.0, v61.1]

**Smartphone (please complete the following information):**
 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Mail App [e.g. GMail, Apple Mail] 
 - Version [e.g. 22]
